### PR TITLE
Port httpsig to use pyca's Cryptography rather than PyCrypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg
 *.egg-info
+.eggs/
 *.pyc
 *~
 .noseids

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python: 2.7
 
 env:
-  - TOX_ENV=py2.7
-  - TOX_ENV=py3.2
-  - TOX_ENV=py3.3
-  - TOX_ENV=py3.4
+  - TOX_ENV=py27
+  - TOX_ENV=py32
+  - TOX_ENV=py33
+  - TOX_ENV=py34
   - TOX_ENV=pypy
   - TOX_ENV=pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TOX_ENV=pypy
   - TOX_ENV=pypy3
 
-install: tox
+install:
+  - pip install tox
 
 script: tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-install:
-  - pip install .
-  - pip install nose
-script: nosetests 
+python: 2.7
+
+env:
+  - TOX_ENV=py2.7
+  - TOX_ENV=py3.2
+  - TOX_ENV=py3.3
+  - TOX_ENV=py3.4
+  - TOX_ENV=pypy
+  - TOX_ENV=pypy3
+
+install: tox
+
+script: tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ httpsig
 
 .. image:: https://travis-ci.org/ahknight/httpsig.svg?branch=master
     :target: https://travis-ci.org/ahknight/httpsig
-    
+
 .. image:: https://travis-ci.org/ahknight/httpsig.svg?branch=develop
     :target: https://travis-ci.org/ahknight/httpsig
 
@@ -20,14 +20,14 @@ See the original project_, original Python module_, original spec_, and `current
 Requirements
 ------------
 
-* Python 2.7, 3.2, 3.3, 3.4
-* PyCrypto_
+* Python 2.7, 3.2, 3.3, 3.4 (or PyPy)
+* Cryptography_
 
 Optional:
 
 * requests_
 
-.. _PyCrypto: https://pypi.python.org/pypi/pycrypto
+.. _Cryptography: https://pypi.python.org/pypi/cryptography
 .. _requests: https://pypi.python.org/pypi/requests
 
 Usage
@@ -40,21 +40,21 @@ For simple raw signing:
 .. code:: python
 
     import httpsig
-    
+
     secret = open('rsa_private.pem', 'rb').read()
-    
+
     sig_maker = httpsig.Signer(secret=secret, algorithm='rsa-sha256')
     sig_maker.sign('hello world!')
 
 For general use with web frameworks:
-    
+
 .. code:: python
 
     import httpsig
-    
+
     key_id = "Some Key ID"
     secret = b'some big secret'
-    
+
     hs = httpsig.HeaderSigner(key_id, secret, algorithm="hmac-sha256", headers=['(request-target)', 'host', 'date'])
     signed_headers_dict = hs.sign({"Date": "Tue, 01 Jan 2014 01:01:01 GMT", "Host": "example.com"}, method="GET", path="/api/1/object/1")
 
@@ -65,11 +65,11 @@ For use with requests:
     import json
     import requests
     from httpsig.requests_auth import HTTPSignatureAuth
-    
+
     secret = open('rsa_private.pem', 'rb').read()
-    
+
     auth = HTTPSignatureAuth(key_id='Test', secret=secret)
-    z = requests.get('https://api.example.com/path/to/endpoint', 
+    z = requests.get('https://api.example.com/path/to/endpoint',
                              auth=auth, headers={'X-Api-Version': '~6.5'})
 
 Class initialization parameters
@@ -81,8 +81,8 @@ Note that keys and secrets should be bytes objects.  At attempt will be made to 
 
     httpsig.Signer(secret, algorithm='rsa-sha256')
 
-``secret``, in the case of an RSA signature, is a string containing private RSA pem. In the case of HMAC, it is a secret password.  
-``algorithm`` is one of the six allowed signatures: ``rsa-sha1``, ``rsa-sha256``, ``rsa-sha512``, ``hmac-sha1``, ``hmac-sha256``, 
+``secret``, in the case of an RSA signature, is a string containing private RSA pem. In the case of HMAC, it is a secret password.
+``algorithm`` is one of the six allowed signatures: ``rsa-sha1``, ``rsa-sha256``, ``rsa-sha512``, ``hmac-sha1``, ``hmac-sha256``,
 ``hmac-sha512``.
 
 
@@ -90,8 +90,8 @@ Note that keys and secrets should be bytes objects.  At attempt will be made to 
 
     httpsig.requests_auth.HTTPSignatureAuth(key_id, secret, algorithm='rsa-sha256', headers=None)
 
-``key_id`` is the label by which the server system knows your RSA signature or password.  
-``headers`` is the list of HTTP headers that are concatenated and used as signing objects. By default it is the specification's minimum, the ``Date`` HTTP header.  
+``key_id`` is the label by which the server system knows your RSA signature or password.
+``headers`` is the list of HTTP headers that are concatenated and used as signing objects. By default it is the specification's minimum, the ``Date`` HTTP header.
 ``secret`` and ``algorithm`` are as above.
 
 Tests

--- a/httpsig/sign.py
+++ b/httpsig/sign.py
@@ -15,20 +15,20 @@ class Signer(object):
     """
     When using an RSA algo, the secret is a PEM-encoded private key.
     When using an HMAC algo, the secret is the HMAC signing secret.
-    
+
     Password-protected keyfiles are not supported.
     """
     def __init__(self, secret, algorithm=None):
         if algorithm is None:
             algorithm = DEFAULT_SIGN_ALGORITHM
-        
+
         assert algorithm in ALGORITHMS, "Unknown algorithm"
         if isinstance(secret, six.string_types): secret = secret.encode("ascii")
-        
+
         self._rsa = None
         self._hash = None
         self.sign_algorithm, self.hash_algorithm = algorithm.split('-')
-        
+
         if self.sign_algorithm == 'rsa':
 
             try:
@@ -36,11 +36,11 @@ class Signer(object):
                 self._rsa = serialization.load_pem_traditional_openssl_private_key(secret, None, backend=default_backend())
             except ValueError, e:
                 raise HttpSigException("Invalid key.")
-                         
-            
-            
+
+
+
         elif self.sign_algorithm == 'hmac':
-            
+
             self._hash = hmac.HMAC(secret,
                                    HASHES[self.hash_algorithm](),
                                    backend=default_backend())
@@ -86,7 +86,7 @@ class HeaderSigner(Signer):
     def __init__(self, key_id, secret, algorithm=None, headers=None):
         if algorithm is None:
             algorithm = DEFAULT_SIGN_ALGORITHM
-        
+
         super(HeaderSigner, self).__init__(secret=secret, algorithm=algorithm)
         self.headers = headers or ['date']
         self.signature_template = build_signature_template(key_id, algorithm, headers)
@@ -103,9 +103,8 @@ class HeaderSigner(Signer):
         headers = CaseInsensitiveDict(headers)
         required_headers = self.headers or ['date']
         signable = generate_message(required_headers, headers, host, method, path)
-        
+
         signature = self._sign(signable)
         headers['authorization'] = self.signature_template % signature
-        
-        return headers
 
+        return headers

--- a/httpsig/sign.py
+++ b/httpsig/sign.py
@@ -13,7 +13,7 @@ DEFAULT_SIGN_ALGORITHM = "hmac-sha256"
 
 class Signer(object):
     """
-    When using an RSA algo, the secret is a PEM-encoded private key.
+    When using an RSA algo, the secret is a PEM-encoded private or public key.
     When using an HMAC algo, the secret is the HMAC signing secret.
 
     Password-protected keyfiles are not supported.
@@ -42,11 +42,8 @@ class Signer(object):
                 try:
                     self._rsa_public = serialization.load_pem_public_key(secret,
                                                                          backend=default_backend())
-
                 except ValueError as e:
                     raise HttpSigException("Invalid key.")
-
-
 
         elif self.sign_algorithm == 'hmac':
 

--- a/httpsig/utils.py
+++ b/httpsig/utils.py
@@ -11,11 +11,10 @@ except ImportError:
     # Python 2
     from urllib2 import parse_http_list
 
-from Crypto.PublicKey import RSA
-from Crypto.Hash import SHA, SHA256, SHA512
+from cryptography.hazmat.primitives.hashes import SHA1, SHA256, SHA512
 
 ALGORITHMS = frozenset(['rsa-sha1', 'rsa-sha256', 'rsa-sha512', 'hmac-sha1', 'hmac-sha256', 'hmac-sha512'])
-HASHES = {'sha1':   SHA,
+HASHES = {'sha1':   SHA1,
           'sha256': SHA256,
           'sha512': SHA512}
 

--- a/httpsig/verify.py
+++ b/httpsig/verify.py
@@ -3,9 +3,10 @@ Module to assist in verifying a signed header.
 """
 import six
 
-from Crypto.Hash import HMAC
-from Crypto.PublicKey import RSA
-from Crypto.Signature import PKCS1_v1_5
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, hmac, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+
 from base64 import b64decode
 
 from .sign import Signer
@@ -29,9 +30,10 @@ class Verifier(Signer):
         if isinstance(signature, six.string_types): signature = signature.encode("ascii")
         
         if self.sign_algorithm == 'rsa':
-            h = self._hash.new()
+            
+            h = self._rsa.public_key().verifier(b64decode(signature), padding.PKCS1v15(), self._rsahash())
             h.update(data)
-            return self._rsa.verify(h, b64decode(signature))
+            return self._rsa.verify()
         
         elif self.sign_algorithm == 'hmac':
             h = self._sign_hmac(data)

--- a/httpsig/verify.py
+++ b/httpsig/verify.py
@@ -6,6 +6,7 @@ import six
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.exceptions import InvalidSignature
 
 from base64 import b64decode
 
@@ -25,21 +26,27 @@ class Verifier(Signer):
         `data` is the message to verify
         `signature` is a base64-encoded signature to verify against `data`
         """
-        
+
         if isinstance(data, six.string_types): data = data.encode("ascii")
         if isinstance(signature, six.string_types): signature = signature.encode("ascii")
-        
+
         if self.sign_algorithm == 'rsa':
-            
-            h = self._rsa.public_key().verifier(b64decode(signature), padding.PKCS1v15(), self._rsahash())
+
+            h = self._rsa_public.verifier(b64decode(signature),
+                                          padding.PKCS1v15(),
+                                          self._rsahash())
             h.update(data)
-            return self._rsa.verify()
-        
+            try:
+                h.verify()
+                return True
+            except InvalidSignature:
+                return False
+
         elif self.sign_algorithm == 'hmac':
             h = self._sign_hmac(data)
             s = b64decode(signature)
             return (h == s)
-        
+
         else:
             raise HttpSigException("Unsupported algorithm.")
 
@@ -51,7 +58,7 @@ class HeaderVerifier(Verifier):
     def __init__(self, headers, secret, required_headers=None, method=None, path=None, host=None):
         """
         Instantiate a HeaderVerifier object.
-        
+
         :param headers:             A dictionary of headers from the HTTP request.
         :param secret:              The HMAC secret or RSA *public* key.
         :param required_headers:    Optional. A list of headers required to be present to validate, even if the signature is otherwise valid.  Defaults to ['date'].
@@ -60,33 +67,33 @@ class HeaderVerifier(Verifier):
         :param host:                Optional. The value to use for the Host header, if not supplied in :param:headers.
         """
         required_headers = required_headers or ['date']
-        
+
         auth = parse_authorization_header(headers['authorization'])
         if len(auth) == 2:
             self.auth_dict = auth[1]
         else:
             raise HttpSigException("Invalid authorization header.")
-        
+
         self.headers = CaseInsensitiveDict(headers)
         self.required_headers = [s.lower() for s in required_headers]
         self.method = method
         self.path = path
         self.host = host
-        
+
         super(HeaderVerifier, self).__init__(secret, algorithm=self.auth_dict['algorithm'])
 
     def verify(self):
         """
         Verify the headers based on the arguments passed at creation and current properties.
-        
+
         Raises an Exception if a required header (:param:required_headers) is not found in the signature.
         Returns True or False.
         """
         auth_headers = self.auth_dict.get('headers', 'date').split(' ')
-        
+
         if len(set(self.required_headers) - set(auth_headers)) > 0:
             raise Exception('{} is a required header(s)'.format(', '.join(set(self.required_headers)-set(auth_headers))))
-        
+
         signing_str = generate_message(auth_headers, self.headers, self.host, self.method, self.path)
-        
+
         return self._verify(signing_str, self.auth_dict['signature'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyCrypto
 six
+cryptography

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=True,
-    install_requires=['pycrypto', 'six'],
+    install_requires=['six', 'cryptography'],
     test_suite="httpsig.tests",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py32, py33, py34
+envlist = py27, py32, py33, py34, pypy, pypy3
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
This changes httpsig to use Cryptography (cryptography.io) instead of PyCrypto. It means it fully supports PyPy/PyPy3, as well as Python 3.4 officially.