### PR TITLE
Switched from PyCrypto to pycryptodome

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,13 +21,13 @@ Requirements
 ------------
 
 * Python 2.7, 3.2, 3.3, 3.4
-* PyCrypto_
+* pycryptodome_
 
 Optional:
 
 * requests_
 
-.. _PyCrypto: https://pypi.python.org/pypi/pycrypto
+.. _pycryptodome: https://pypi.python.org/pypi/pycryptodome
 .. _requests: https://pypi.python.org/pypi/requests
 
 Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyCrypto
+pycryptodome==3.4.7
 six

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=True,
-    install_requires=['pycrypto', 'six'],
+    install_requires=['pycryptodome==3.4.7', 'six'],
     test_suite="httpsig.tests",
 )


### PR DESCRIPTION
PyCrypto is no longer maintained, and pycryptodome is a drop-in replacement. Many libraries depending on httpsig will no longer have a great experience especially installing httpsig on platforms where PyCrypto is no longer compiling or supported.