### PR TITLE
Relax pycryptodome requirement: Accept any 3.x.x version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycryptodome==3.4.7
+pycryptodome==3.6.1
 six

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     zip_safe=True,
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
-    install_requires=['pycryptodome==3.4.7', 'six'],
+    install_requires=['pycryptodome>=3,<4', 'six'],
     test_suite="httpsig.tests",
 )


### PR DESCRIPTION
Closes #13