### PR TITLE
less strict pycryptodome version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pycryptodome==3.6.1
+pycryptodome<4,>=3.6.1
 six


### PR DESCRIPTION
beside the annoyingly setup issues, pycryptodome improved a lot since 3.6 and it has no breaking changes for this lib